### PR TITLE
fix smooth alerts

### DIFF
--- a/src/components/alert/Alert.vue
+++ b/src/components/alert/Alert.vue
@@ -1,5 +1,5 @@
 <template>
-    <md-snackbar :md-position="position" :md-duration="isInfinity ? Infinity : duration" :md-active.sync="showSnackbar">
+    <md-snackbar :md-position="position" :md-duration="duration" :md-active="show">
         <span>{{message}}</span>
     </md-snackbar>
 </template>
@@ -14,18 +14,9 @@ import {namespace as alertNamespace} from '@/store/modules/alert/alert.store';
 export default class Alert extends Vue {
     @State('message', {namespace: alertNamespace}) message!: string;
     @State('duration', {namespace: alertNamespace}) duration!: number;
-    
-    @Watch('message')
-    status(oldValue, newValue) {
-        if(!newValue) {
-            this.showSnackbar = false;
-        }
-        this.showSnackbar = true;
-    }
+    @State('show', {namespace: alertNamespace}) show!: boolean;
 
     position: string = 'center';
-    showSnackbar: boolean = false;
-    isInfinity: boolean = false;
 }
 </script>
 

--- a/src/store/modules/alert/alert.actions.ts
+++ b/src/store/modules/alert/alert.actions.ts
@@ -2,13 +2,39 @@ import {ActionTree} from 'vuex';
 import {IAlertState} from './alert.store';
 import {IRootState} from '../../index';
 
+import {
+	mutationSetActiveTimeout,
+	mutationSetMessage,
+	mutationClearMessage,
+	mutationSetShow
+} from './alert.mutations';
+
 export const actionShowMessage: string = 'showMessage';
+export const actionSetActiveTimeout: string = 'setActiveTimeout';
 
 export const actions: ActionTree<IAlertState, IRootState> = {
 	[actionShowMessage]({commit, dispatch, state}, message: string) {
-		state.message = message;
-		setTimeout(() => {
-			state.message = '';
+		if (state.message) {
+			commit(mutationSetShow, false);
+			commit(mutationClearMessage);
+			setTimeout(() => {
+				commit(mutationSetMessage, message);
+				commit(mutationSetShow, true);
+				dispatch(actionSetActiveTimeout);
+			}, 300);
+		} else {
+			commit(mutationSetMessage, message);
+			commit(mutationSetShow, true);
+			dispatch(actionSetActiveTimeout);
+		}
+	},
+	[actionSetActiveTimeout]({commit, dispatch, state}) {
+		if (state.activeTimeout) {
+			clearTimeout(state.activeTimeout);
+		}
+		state.activeTimeout = setTimeout(() => {
+			commit(mutationClearMessage);
+			commit(mutationSetShow, false);
 		}, state.duration);
 	}
 };

--- a/src/store/modules/alert/alert.mutations.ts
+++ b/src/store/modules/alert/alert.mutations.ts
@@ -1,4 +1,22 @@
 import {MutationTree} from 'vuex';
 import {IAlertState} from './alert.store';
 
-export const mutations: MutationTree<IAlertState> = {};
+export const mutationSetMessage: string = 'setMessage';
+export const mutationSetShow: string = 'setShow';
+export const mutationSetActiveTimeout: string = 'setActiveTimeout';
+export const mutationClearMessage: string = 'clearMessage';
+
+export const mutations: MutationTree<IAlertState> = {
+	[mutationSetMessage](state, message: string) {
+		state.message = message;
+	},
+	[mutationClearMessage](state) {
+		state.message = '';
+	},
+	[mutationSetShow](state, show: boolean) {
+		state.show = show;
+	},
+	[mutationSetActiveTimeout](state, activeTimeout: any) {
+		state.activeTimeout = activeTimeout;
+	}
+};

--- a/src/store/modules/alert/alert.store.ts
+++ b/src/store/modules/alert/alert.store.ts
@@ -3,16 +3,20 @@ import {IRootState} from '../../index';
 import {actions} from './alert.actions';
 import {mutations} from './alert.mutations';
 
-export const namespace = 'alert';
+export const namespace: string = 'alert';
 
 export interface IAlertState {
 	message: string;
 	duration: number;
+	show: boolean;
+	activeTimeout: any;
 }
 
 export const state: IAlertState = {
 	message: '',
-	duration: 4000
+	duration: 4000,
+	show: false,
+	activeTimeout: null
 };
 
 const namespaced: boolean = true;


### PR DESCRIPTION
If an alert is already active with a ticking timeout, close that alert and replace it with new alert and a new timeout to make stacking alerts smoooooth as hell.